### PR TITLE
Konflux Onboarding Prerequisites

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,67 @@
+target
+work
+
+# IntelliJ project files 
+*.iml
+*.iws
+*.ipr
+/.idea/*
+!/.idea/icon.svg
+!/.idea/.name
+!/.idea/encodings.xml
+out
+
+# Eclipse and VSCode project files
+.settings
+.classpath
+.project
+.factorypath
+build
+
+# VSCode workspace file
+*.code-workspace
+
+# vim
+*~
+*.swp
+
+# ctags
+tags
+
+# OS X
+.DS_Store
+
+# mvn versions:set
+pom.xml.versionsBackup
+
+war/images/16x16
+war/images/24x24
+war/images/32x32
+war/images/48x48
+jenkins.war
+RPMS
+SRPMS
+debian/binary
+debian/debian/jenkins
+debian/debian/jenkins.substvars
+debian/debian/files
+debian/build-stamp
+debian/configure-stamp
+*.debhelper
+*.debhelper.log
+jenkins_*.build
+jenkins_*.changes
+*.deb
+*.pkg
+*.zip
+push-build.sh
+war/node_modules/
+war/yarn-error.log
+.java-version
+.checkstyle
+
+# Non-application files versioned in git
+.github
+.gitpod
+.konflux
+.tekton

--- a/.konflux/Containerfile
+++ b/.konflux/Containerfile
@@ -1,0 +1,24 @@
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.20
+
+# Jenkins .war requires git to be present for the build.
+USER root
+RUN microdnf install -y git
+
+USER 185
+
+# Jenkins runs in an "executable .war" file, packaging its own Jetty servlet.
+# These environment variables tune the s2i assemble script to execute a quick build of the Jenkins
+# .war file. JAVA_APP_JAR instructs the s2i run script to run the app using the executable war.
+ENV JAVA_APP_JAR="jenkins.war" \ 
+    MAVEN_ARGS="-am -pl war,bom -Pquick-build" \
+    MAVEN_S2I_ARTIFACT_DIRS="war/target" \
+    MAVEN_S2I_GOALS="clean install" \
+    S2I_SOURCE_DEPLOYMENTS_FILTER="*.war"
+
+# Copying in source code. Red Hat OpenJDK S2I buiders expect source content in /tmp/src by default
+COPY --chown=185:0 . /tmp/src
+
+RUN /usr/local/s2i/assemble
+# Run script sourced from builder image based on user input or image metadata.
+# If this file does not exist in the image, the build will fail.
+CMD /usr/local/s2i/run


### PR DESCRIPTION
Onboard the Jenkins WAR assembly to Konflux by packaging the core jenkins.war into a container image. For now this is packaged in full container image, complete with JDK development tools to facilitate testing. In the future, the .war file should be packaged in either a smaller "runtime" container image or distributed as an OCI artifact.
