### PR TITLE
Use OpenJDK Runtime Image

### DIFF
--- a/.konflux/Containerfile
+++ b/.konflux/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.20-2.1721752936
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.20-2.1721752936 as builder
 
 # Jenkins .war requires git to be present for the build.
 USER root
@@ -8,9 +8,8 @@ USER 185
 
 # Jenkins runs in an "executable .war" file, packaging its own Jetty servlet.
 # These environment variables tune the s2i assemble script to execute a quick build of the Jenkins
-# .war file. JAVA_APP_JAR instructs the s2i run script to run the app using the executable war.
-ENV JAVA_APP_JAR="jenkins.war" \ 
-    MAVEN_ARGS="-am -pl war,bom -Pquick-build" \
+# .war file.
+ENV MAVEN_ARGS="-am -pl war,bom -Pquick-build" \
     MAVEN_S2I_ARTIFACT_DIRS="war/target" \
     MAVEN_S2I_GOALS="clean install" \
     S2I_SOURCE_DEPLOYMENTS_FILTER="*.war"
@@ -19,6 +18,16 @@ ENV JAVA_APP_JAR="jenkins.war" \
 COPY --chown=185:0 . /tmp/src
 
 RUN /usr/local/s2i/assemble
-# Run script sourced from builder image based on user input or image metadata.
-# If this file does not exist in the image, the build will fail.
-CMD /usr/local/s2i/run
+
+# Use slimmer runtime image for deploying Jenkins
+FROM registry.redhat.io/ubi9/openjdk-21-runtime:1.20-2.1721752928
+
+USER root
+RUN microdnf install -y \
+    fontconfig \
+    freetype
+
+USER 185
+COPY --from=builder --chown=185:0 /deployments/*.war /deployments/
+# JAVA_APP_JAR instructs the image run script to use the executable war as its main class.
+ENV JAVA_APP_JAR="jenkins.war"


### PR DESCRIPTION
Package the .war into a thinner runtime image. This hopefully will reduce the number of vulnerabilities detected by our scanning tools. Reduced image size is a significant bonus (1.74GB -> 493 MB).
