### PR TITLE
JKNS-539: Build Source Image

### DIFF
--- a/.tekton/jenkinsci-jenkins-4-17-pull-request.yaml
+++ b/.tekton/jenkinsci-jenkins-4-17-pull-request.yaml
@@ -28,6 +28,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: .konflux/Containerfile
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/jenkinsci-jenkins-4-17-push.yaml
+++ b/.tekton/jenkinsci-jenkins-4-17-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-tools-jenkins-tenant/jenkinsci-jenkins-4-17:{{revision}}
   - name: dockerfile
     value: .konflux/Containerfile
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
Build the source image for the `jenkins.war` binary.
